### PR TITLE
add body.Close() on check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"os"
@@ -103,7 +104,8 @@ func (c client) try(ctx context.Context, request Request, cancelFunc context.Can
 
 	for _, fm := range request.failManagers {
 		if err := fm.Check(resp); err != nil {
-			defer resp.Body.Close()
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
 			return Response{}, err
 		}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -104,7 +104,7 @@ func (c client) try(ctx context.Context, request Request, cancelFunc context.Can
 
 	for _, fm := range request.failManagers {
 		if err := fm.Check(resp); err != nil {
-			ioutil.ReadAll(resp.Body)
+			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
 			return Response{}, err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -103,6 +103,7 @@ func (c client) try(ctx context.Context, request Request, cancelFunc context.Can
 
 	for _, fm := range request.failManagers {
 		if err := fm.Check(resp); err != nil {
+			defer resp.Body.Close()
 			return Response{}, err
 		}
 	}


### PR DESCRIPTION
**Context**
Body in response needs to be closed to avoid memory-leaks
**Problem**
The Check() function will swallow the body and return a emtpy struct. Making it impossible for the user of the lib to close the body.
This leads to memory-leaks.
**Solution**
read and close body before returning empty struct.
