### PR TITLE
Handle session ids

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/wrapp/instrumentation/requestid"
+	"github.com/wrapp/instrumentation/sessionid"
 )
 
 var logger zerolog.Logger
@@ -26,6 +27,7 @@ func New(ctx context.Context, funcs ...func(zerolog.Context) zerolog.Context) *z
 
 	funcs = append(funcs, WithServiceName())
 	funcs = append(funcs, WithRequestID(ctx))
+	funcs = append(funcs, WithSessionID(ctx))
 	for _, apply := range funcs {
 		log = apply(log)
 	}
@@ -72,6 +74,17 @@ func WithRequestID(ctx context.Context) func(zerolog.Context) zerolog.Context {
 			return log
 		}
 		return log.Str("request_id", requestID)
+	}
+}
+
+// WithSessionID injects the session id in the logs.
+func WithSessionID(ctx context.Context) func(zerolog.Context) zerolog.Context {
+	return func(log zerolog.Context) zerolog.Context {
+		sessionID := sessionid.Get(ctx)
+		if sessionID == "" {
+			return log
+		}
+		return log.Str("session_id", sessionID)
 	}
 }
 

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wrapp/instrumentation/logs"
 	"github.com/wrapp/instrumentation/requestid"
+	"github.com/wrapp/instrumentation/sessionid"
 )
 
 func TestMaskSSN(t *testing.T) {
@@ -44,6 +45,7 @@ func TestNew(t *testing.T) {
 	type log struct {
 		Level     string `json:"level"`
 		RequestID string `json:"request_id"`
+		SessionID string `json:"session_id"`
 		Service   string `json:"service"`
 		Msg       string `json:"msg"`
 	}
@@ -51,12 +53,14 @@ func TestNew(t *testing.T) {
 	expected := log{
 		Level:     "info",
 		RequestID: "my-request-id",
+		SessionID: "my-session-id",
 		Service:   "my-service-name",
 		Msg:       "my-message",
 	}
 
 	os.Setenv("SERVICE_NAME", expected.Service)
 	ctx := requestid.Store(context.Background(), expected.RequestID)
+	ctx = sessionid.Store(ctx, expected.SessionID)
 
 	var out bytes.Buffer
 	logger := logs.New(ctx, logs.WithRequestID(ctx)).Output(&out)

--- a/sessionid/session_id.go
+++ b/sessionid/session_id.go
@@ -1,0 +1,45 @@
+package sessionid
+
+import (
+	"context"
+	"net/http"
+)
+
+type key string
+
+const (
+	contextSessionID key = "session-id"
+)
+
+// Middleware injects the session in the context
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.Header.Get("X-Session-ID")
+		if sessionID == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Add("X-Session-ID", sessionID)
+		next.ServeHTTP(w, r.WithContext(Store(r.Context(), sessionID)))
+	})
+}
+
+// Store stores the request ID in the given context.
+func Store(parent context.Context, sessionID string) context.Context {
+	return context.WithValue(parent, contextSessionID, sessionID)
+}
+
+// Get returns the request ID from the context.
+func Get(ctx context.Context) string {
+	v := ctx.Value(contextSessionID)
+	if v == nil {
+		return ""
+	}
+
+	sessionID, ok := ctx.Value(contextSessionID).(string)
+	if !ok {
+		return ""
+	}
+	return sessionID
+}

--- a/sessionid/session_id_test.go
+++ b/sessionid/session_id_test.go
@@ -1,0 +1,39 @@
+package sessionid_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wrapp/instrumentation/client"
+	"github.com/wrapp/instrumentation/requestid"
+	"github.com/wrapp/instrumentation/sessionid"
+)
+
+func TestStoreAndGet(t *testing.T) {
+	expectedSessionID := "some-request-id"
+	ctx := requestid.Store(context.Background(), expectedSessionID)
+
+	requestID := requestid.Get(ctx)
+	if requestID != expectedSessionID {
+		t.Fatalf("expected %v got %v", expectedSessionID, requestID)
+	}
+}
+func TestMiddleware(t *testing.T) {
+	const expected = "some-session-id"
+
+	server := httptest.NewServer(sessionid.Middleware(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			sessionID := sessionid.Get(r.Context())
+			if sessionID != expected {
+				t.Fatalf("expected a %s, got %v", expected, sessionID)
+			}
+		})))
+	cli, _ := client.New()
+	_, err := cli.Get(context.Background(), server.URL,
+		client.Header("X-Session-ID", expected))
+	if err != nil {
+		t.Fatalf("got an unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
# Motivation
Our clients starts to use the session id as a key to group request from the same session. This PR adds a way to extract that session ID from the headers and injects it in the context and in the logs.