### PR TITLE
REWARDS-1940: Adding X-Amzn-Trace-Id Header to middlewares, clients and logs

### DIFF
--- a/awstraceid/awstraceid.go
+++ b/awstraceid/awstraceid.go
@@ -10,11 +10,12 @@ type key string
 const (
 	// awsTraceIDKey used for the context-key
 	awsTraceIDKey key = "amazonTraceId"
-	// AWSTraceIDHeader is the httpHeader used for the aws-trace-id
+	// AWSTraceIDHeader is the httpHeader used for the tracing request through
+	// aws load-balancers
 	AWSTraceIDHeader = "X-Amzn-Trace-Id"
 )
 
-// Middleware injects the session in the context
+// Middleware injects the amazon-traceID in the context
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		awsTraceID := r.Header.Get(AWSTraceIDHeader)
@@ -33,7 +34,7 @@ func Store(parent context.Context, awsTraceID string) context.Context {
 	return context.WithValue(parent, awsTraceIDKey, awsTraceID)
 }
 
-// Get returns the request ID from the context.
+// Get returns the awsTraceID from the context.
 func Get(ctx context.Context) string {
 	v := ctx.Value(awsTraceIDKey)
 	if v == nil {

--- a/awstraceid/awstraceid.go
+++ b/awstraceid/awstraceid.go
@@ -1,0 +1,48 @@
+package awstraceid
+
+import (
+	"context"
+	"net/http"
+)
+
+type key string
+
+const (
+	// awsTraceIDKey used for the context-key
+	awsTraceIDKey key = "amazonTraceId"
+	// AWSTraceIDHeader is the httpHeader used for the aws-trace-id
+	AWSTraceIDHeader = "X-Amzn-Trace-Id"
+)
+
+// Middleware injects the session in the context
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		awsTraceID := r.Header.Get(AWSTraceIDHeader)
+		if awsTraceID == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Add(AWSTraceIDHeader, awsTraceID)
+		next.ServeHTTP(w, r.WithContext(Store(r.Context(), awsTraceID)))
+	})
+}
+
+// Store returns a copy of the input context with the awsTraceId ammended.
+func Store(parent context.Context, awsTraceID string) context.Context {
+	return context.WithValue(parent, awsTraceIDKey, awsTraceID)
+}
+
+// Get returns the request ID from the context.
+func Get(ctx context.Context) string {
+	v := ctx.Value(awsTraceIDKey)
+	if v == nil {
+		return ""
+	}
+
+	awsTraceID, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return awsTraceID
+}

--- a/awstraceid/awstraceid_test.go
+++ b/awstraceid/awstraceid_test.go
@@ -1,0 +1,37 @@
+package awstraceid_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wrapp/instrumentation/awstraceid"
+	"github.com/wrapp/instrumentation/client"
+)
+
+func TestStoreAndGet(t *testing.T) {
+	expectedAwsTraceID := "some-banan-id"
+	ctx := awstraceid.Store(context.Background(), expectedAwsTraceID)
+	gotTraceID := awstraceid.Get(ctx)
+	if gotTraceID != expectedAwsTraceID {
+		t.Fatalf("expected %v got %v", expectedAwsTraceID, gotTraceID)
+	}
+}
+func TestMiddleware(t *testing.T) {
+	const expected = "some-banan-id"
+
+	server := httptest.NewServer(awstraceid.Middleware(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotTraceID := awstraceid.Get(r.Context())
+			if gotTraceID != expected {
+				t.Fatalf("expected a %s, got %v", expected, gotTraceID)
+			}
+		})))
+	cli, _ := client.New()
+	_, err := cli.Get(context.Background(), server.URL,
+		client.Header("X-Amzn-Trace-Id", expected))
+	if err != nil {
+		t.Fatalf("got an unexpected error %v", err)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/wrapp/instrumentation/awstraceid"
 	"github.com/wrapp/instrumentation/requestid"
 	"go.opencensus.io/plugin/ochttp"
 )
@@ -125,6 +126,7 @@ func (c client) do(ctx context.Context, url, method string, funcs ...RequestOpti
 
 	// Applying "battery-included" options.
 	Header("X-Request-ID", requestid.Get(ctx))(&req)
+	Header(awstraceid.AWSTraceIDHeader, awstraceid.Get(ctx))(&req)
 	UserAgent(c.serviceName)(&req)
 
 	// Applying the "on-demand" options

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/wrapp/instrumentation/awstraceid"
 	"github.com/wrapp/instrumentation/logs"
 	"github.com/wrapp/instrumentation/requestid"
 	"github.com/wrapp/instrumentation/sessionid"
@@ -43,25 +44,27 @@ func TestMaskSSN(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	type log struct {
-		Level     string `json:"level"`
-		RequestID string `json:"request_id"`
-		SessionID string `json:"session_id"`
-		Service   string `json:"service"`
-		Msg       string `json:"msg"`
+		Level      string `json:"level"`
+		RequestID  string `json:"request_id"`
+		SessionID  string `json:"session_id"`
+		AWSTraceID string `json:"aws_trace_id"`
+		Service    string `json:"service"`
+		Msg        string `json:"msg"`
 	}
 
 	expected := log{
-		Level:     "info",
-		RequestID: "my-request-id",
-		SessionID: "my-session-id",
-		Service:   "my-service-name",
-		Msg:       "my-message",
+		Level:      "info",
+		RequestID:  "my-request-id",
+		SessionID:  "my-session-id",
+		AWSTraceID: "my-aws-trace-id",
+		Service:    "my-service-name",
+		Msg:        "my-message",
 	}
 
 	os.Setenv("SERVICE_NAME", expected.Service)
 	ctx := requestid.Store(context.Background(), expected.RequestID)
 	ctx = sessionid.Store(ctx, expected.SessionID)
-
+	ctx = awstraceid.Store(ctx, expected.AWSTraceID)
 	var out bytes.Buffer
 	logger := logs.New(ctx, logs.WithRequestID(ctx)).Output(&out)
 


### PR DESCRIPTION
**Context**
X-Amzn-Trace-Id is used by aws services do trace down how http-requests propgate through different systems.
We are working on adding ALB-logs, and this trace-id will be shown there.

**Problem**
We do not propagate this ID through our system and the access-logs are not as useful if we cannot correlate the trace-ID with other events in our system.


**Solution**
- Create middleware for using to receive aws-trace-id (from incomming http-requests) and store in context, for later use.
- Create default behavior in the client-lib to add the aws-trace-id to requests, if present in context
- Add aws-trace-id in default log-output
