### PR TITLE
Validation error check

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -47,6 +47,16 @@ func (ve ValidationErrors) Error() string {
 	return strings.TrimSpace(buff.String())
 }
 
+// Extensions provide a map of the error properties
+func (ve ValidationErrors) Extensions() map[string]interface{} {
+	m := map[string]interface{}{
+		"message": "Field validation",
+		"valid":   ve.Valid,
+		"fields":  ve.Errors,
+	}
+	return m
+}
+
 // ParseValidationErrors parses a byte array for validation errors
 func ParseValidationErrors(body []byte) (ValidationErrors, error) {
 	var validationErrors ValidationErrors

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	fieldErrMsg = "Context: '%s' Error:Field validation for '%s' failed. Expected: %s but given: %s"
+)
+
+// FieldError describes error of a field
+type FieldError struct {
+	Context  string `json:"context"`
+	Field    string `json:"field"`
+	Expected string `json:"expected"`
+	Given    string `json:"given"`
+}
+
+func (fe FieldError) Error() string {
+	return fmt.Sprintf(fieldErrMsg, fe.Context, fe.Field, fe.Expected, fe.Given)
+}
+
+// ValidationErrors is an array of FieldError's
+// for use in custom error messages post validation.
+type ValidationErrors struct {
+	Valid  bool         `json:"valid"`
+	Errors []FieldError `json:"errors"`
+}
+
+// Error creates an error message from array of validation errors
+func (ve ValidationErrors) Error() string {
+
+	buff := bytes.NewBufferString("Validation Errors:\n")
+
+	var fe *FieldError
+
+	for i := 0; i < len(ve.Errors); i++ {
+
+		fe = &ve.Errors[i]
+		buff.WriteString(fe.Error())
+		buff.WriteString("\n")
+	}
+
+	return strings.TrimSpace(buff.String())
+}
+
+// ParseValidationErrors parses a byte array for validation errors
+func ParseValidationErrors(body []byte) (ValidationErrors, error) {
+	var validationErrors ValidationErrors
+	if err := json.NewDecoder(bytes.NewBuffer(body)).Decode(&validationErrors); err != nil {
+		return ValidationErrors{}, errors.Wrap(err, "failed to parse validation errors")
+	}
+	return validationErrors, nil
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -53,7 +51,7 @@ func (ve ValidationErrors) Error() string {
 func ParseValidationErrors(body []byte) (ValidationErrors, error) {
 	var validationErrors ValidationErrors
 	if err := json.NewDecoder(bytes.NewBuffer(body)).Decode(&validationErrors); err != nil {
-		return ValidationErrors{}, errors.Wrap(err, "failed to parse validation errors")
+		return ValidationErrors{}, fmt.Errorf("Failed to parse validation errors: %w", err)
 	}
 	return validationErrors, nil
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,68 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/wrapp/instrumentation/client"
+)
+
+const validationErrorResponse = `{
+	"valid": false,
+	"errors": [
+	  {
+		"context": "(root).address",
+		"expected": "array",
+		"field": "address",
+		"given": "null"
+	  },
+	  {
+		"context": "(root).postal_code",
+		"expected": "string",
+		"field": "postal_code",
+		"given": "null"
+	  },
+	  {
+		"context": "(root).address_line2",
+		"expected": "string",
+		"field": "address_line2",
+		"given": "null"
+	  },
+	  {
+		"context": "(root).city",
+		"expected": "string",
+		"field": "city",
+		"given": "null"
+	  },
+	  {
+		"context": "(root).country_code",
+		"expected": "string",
+		"field": "country_code",
+		"given": "null"
+	  }
+	],
+	"item": 0
+  }`
+
+func TestParseValidationErrorMessageOveride(t *testing.T) {
+	ve, err := client.ParseValidationErrors([]byte(validationErrorResponse), "Test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Providing custom message overrides the default message
+	if ve.Error() != "Test" {
+		t.Fail()
+	}
+}
+
+func TestParseValidationErrorWithoutMessageOverride(t *testing.T) {
+	ve, err := client.ParseValidationErrors([]byte(validationErrorResponse), "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Providing custom message overrides the default message
+	if ve.Error() == "" {
+		t.Fail()
+	}
+}

--- a/client/failure_option.go
+++ b/client/failure_option.go
@@ -1,6 +1,13 @@
 package client
 
-import "net/http"
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
 
 // FailManager is a failure handler.
 type FailManager interface {
@@ -50,4 +57,39 @@ func StatusBetween(err error, min, max int) FailManager {
 // StatusIsNot creates a FailManager that fails if the status is not in the list.
 func StatusIsNot(err error, statusList ...int) FailManager {
 	return statusChecker{raiseErr: err, statusList: statusList, mustContain: true}
+}
+
+// HasValidationErrors creates a FailManager that fails if the status is StatusBadRequest
+// and the body includes validation errors.
+// The error returned will be of type ValidationErrors wrapped under the given error.
+func HasValidationErrors(err error) FailManager {
+	return validationErrorsChecker{raiseErr: err}
+}
+
+type validationErrorsChecker struct {
+	raiseErr error
+}
+
+func (checker validationErrorsChecker) Check(resp *http.Response) error {
+	if resp.StatusCode != http.StatusBadRequest {
+		return nil
+	}
+	// Retrieve the body
+	body, err := ioutil.ReadAll(resp.Body)
+	defer func(bdy []byte) {
+		// reinject the body because it has been consumed previously, in case someone wants to use it.
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bdy))
+	}(body)
+	if err != nil {
+		return errors.Wrap(checker.raiseErr, fmt.Sprintf("Failed to read body to check for validation errors: %w", err))
+	}
+	validationErrors, err := ParseValidationErrors(body)
+	if err != nil {
+		return errors.Wrap(checker.raiseErr, fmt.Sprintf("Falied to parse validation errors from response body: %w", err))
+	}
+	// In the case the validation result is valid.
+	if validationErrors.Valid {
+		return nil
+	}
+	return errors.Wrap(checker.raiseErr, fmt.Sprintf("%w", validationErrors))
 }

--- a/client/failure_option.go
+++ b/client/failure_option.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // FailManager is a failure handler.
@@ -81,15 +79,15 @@ func (checker validationErrorsChecker) Check(resp *http.Response) error {
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bdy))
 	}(body)
 	if err != nil {
-		return errors.Wrap(checker.raiseErr, fmt.Sprintf("Failed to read body to check for validation errors: %w", err))
+		return fmt.Errorf("%s: %w", checker.raiseErr.Error(), fmt.Errorf("Failed to read body to check for validation errors: %w", err))
 	}
 	validationErrors, err := ParseValidationErrors(body)
 	if err != nil {
-		return errors.Wrap(checker.raiseErr, fmt.Sprintf("Falied to parse validation errors from response body: %w", err))
+		return fmt.Errorf("%s: %w", checker.raiseErr.Error(), fmt.Errorf("Falied to parse validation errors from response body: %w", err))
 	}
 	// In the case the validation result is valid.
 	if validationErrors.Valid {
 		return nil
 	}
-	return errors.Wrap(checker.raiseErr, validationErrors.Error())
+	return fmt.Errorf("%s: %w", checker.raiseErr.Error(), validationErrors)
 }

--- a/client/failure_option.go
+++ b/client/failure_option.go
@@ -89,5 +89,5 @@ func (checker validationErrorsChecker) Check(resp *http.Response) error {
 	if validationErrors.Valid {
 		return nil
 	}
-	return fmt.Errorf("%s: %w", checker.raiseErr.Error(), validationErrors)
+	return validationErrors
 }

--- a/client/failure_option.go
+++ b/client/failure_option.go
@@ -81,7 +81,7 @@ func (checker validationErrorsChecker) Check(resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", checker.raiseErr.Error(), fmt.Errorf("Failed to read body to check for validation errors: %w", err))
 	}
-	validationErrors, err := ParseValidationErrors(body)
+	validationErrors, err := ParseValidationErrors(body, checker.raiseErr.Error())
 	if err != nil {
 		return fmt.Errorf("%s: %w", checker.raiseErr.Error(), fmt.Errorf("Falied to parse validation errors from response body: %w", err))
 	}

--- a/client/failure_option.go
+++ b/client/failure_option.go
@@ -91,5 +91,5 @@ func (checker validationErrorsChecker) Check(resp *http.Response) error {
 	if validationErrors.Valid {
 		return nil
 	}
-	return errors.Wrap(checker.raiseErr, fmt.Sprintf("%w", validationErrors))
+	return errors.Wrap(checker.raiseErr, validationErrors.Error())
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/m4rw3r/uuid v1.0.0
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.17.2
 	github.com/stretchr/testify v1.4.0
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/m4rw3r/uuid v1.0.0
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.17.2
 	github.com/stretchr/testify v1.4.0
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
### Context
Some of our service endpoints will validate posted payloads using a json validator from this library ( instrumentation ).

### Problem
We don't have a method to parse the error content returned by the json validator.

### Solution
Add a client option to check for validation errors.